### PR TITLE
Fix installation issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 2.8.12)
 project(dqn-hfo)
 
 add_definitions(${Caffe_DEFINITIONS})
-option(CAFFE_CPU_ONLY "Use CPU only for Caffe" OFF)
+option(CPU_ONLY "Use CPU only for Caffe" OFF)
 if(CPU_ONLY)
   add_definitions(-DCPU_ONLY)
 endif()

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ changes:
    }
    int iter() { return iter_; }
 +  void set_iter(int new_iter) { iter_ = new_iter; }
- 
+
    // Invoked at specific points during an iteration
    class Callback {
 @@ -84,7 +85,6 @@ class Solver {
- 
+
    void CheckSnapshotWritePermissions();
- 
+
 - protected:
    // Make and apply the update value for the current iteration.
    virtual void ApplyUpdate() = 0;
@@ -58,18 +58,26 @@ changes:
 ## Errors
 
 ### Cannot find cublas_v2.h:
-```device_alternate.hpp:34:23: fatal error: cublas_v2.h: No such file or directory
+```
+device_alternate.hpp:34:23: fatal error: cublas_v2.h: No such file or directory
  #include <cublas_v2.h>
                        ^
-compilation terminated.```
+compilation terminated.
+```
 
 Solution: Include your Cuda path in the installation:
 
   1. ```locate cublas_v2.h``` -- this should give you the path to your cuda installation
   2. ```export CPLUS_INCLUDE_PATH=/your/cuda/path:$CPLUS_INCLUDE_PATH```
 
-### ```caffe/include/caffe/blob.hpp:9:34: fatal error: caffe/proto/caffe.pb.h: No such file or directory
- #include "caffe/proto/caffe.pb.h"```
+### Cannot find caffe.pb.h:
+```
+caffe/include/caffe/blob.hpp:9:34: fatal error: caffe/proto/caffe.pb.h:
+No such file or directory
+ #include "caffe/proto/caffe.pb.h"
+                                  ^
+compilation terminated.
+```
 
 Solution: Symlink the built proto files.
   1. ```cd your_caffe_dir/include/caffe```

--- a/src/dqn.cpp
+++ b/src/dqn.cpp
@@ -70,7 +70,7 @@ void ZeroGradParameters(caffe::Net<Dtype>& net) {
                          blob->mutable_cpu_diff());
         break;
       case caffe::Caffe::GPU:
-        caffe::caffe_gpu_set(blob->count(), static_cast<Dtype>(0),
+        caffe::caffe_set(blob->count(), static_cast<Dtype>(0),
                              blob->mutable_gpu_diff());
         break;
     }


### PR DESCRIPTION
I had trouble installing with several errors related to my need to not use a GPU. Making the below edits, I was able to install.

- CMakeLists.txt: Using CAFFE_CPU_ONLY instead of CPU_ONLY seemed to cause Caffe to attempt to use cublas_v2.h
- READMET: Changes in README separate the two errors more clearly. A quick look in the prior version would cause a user to miss the second error
- dqn.cpp: caffe does not have a member caffe_gpu_set